### PR TITLE
support cabal 1.18

### DIFF
--- a/cabal-test-hunit.cabal
+++ b/cabal-test-hunit.cabal
@@ -12,5 +12,5 @@ Cabal-version:       >= 1.2
 Library
   Exposed-modules:     Distribution.TestSuite.HUnit
   Build-depends:       HUnit == 1.2.*,
-                       Cabal >= 1.16, Cabal < 1.17,
+                       Cabal >= 1.16 && < 1.19,
                        base == 4.*


### PR DESCRIPTION
Increase Cabal version boundaries for GHC 7.8 compatibility.
