### PR TITLE
Bump version number to support latest cabal

### DIFF
--- a/cabal-test-hunit.cabal
+++ b/cabal-test-hunit.cabal
@@ -12,5 +12,5 @@ Cabal-version:       >= 1.2
 Library
   Exposed-modules:     Distribution.TestSuite.HUnit
   Build-depends:       HUnit == 1.2.*,
-                       Cabal >= 1.16 && < 1.19,
+                       Cabal >= 1.16 && < 1.23,
                        base == 4.*


### PR DESCRIPTION
I've updated the version number and tested with Cabal 1.22.2.0 and it works fine.